### PR TITLE
Exclude WPF.targets when building on non-Windows OS

### DIFF
--- a/MSBuild.Sdk.Extras/build/platforms/NETFramework.targets
+++ b/MSBuild.Sdk.Extras/build/platforms/NETFramework.targets
@@ -3,7 +3,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)languageTargets\Wpf.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)languageTargets\Wpf.targets" Condition=" '$(OS)' == 'Windows_NT' " />
 
   <!-- Settings only apply to .NET Framework -->
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'True' and '$(EnableDefaultSettingsItems)' == 'true' ">


### PR DESCRIPTION
Fixes onovotny/MSBuildSdkExtras#31